### PR TITLE
Feature/26 Defaults and dataset.query.bbox

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -283,7 +283,7 @@ module.exports = function(grunt) {
       options: {
 
         base: 'site/build'
-        //,repo: 'git@github.com:esridc/cedar.git'
+        ,repo: 'git@github.com:esridc/cedar.git'
 
       },
       src: ['**']

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -283,7 +283,7 @@ module.exports = function(grunt) {
       options: {
 
         base: 'site/build'
-        ,repo: 'git@github.com:esridc/cedar.git'
+        //,repo: 'git@github.com:esridc/cedar.git'
 
       },
       src: ['**']

--- a/site/source/pages/api/json/specification-json.md
+++ b/site/source/pages/api/json/specification-json.md
@@ -15,7 +15,8 @@ Charts are defined by JSON documents (`specification`) which are then linked to 
     { 
       "name": "<string>", 
       "type": ["<string>"], 
-      "required": <boolean>
+      "required": <boolean>,
+      "default": <value>
     } 
   ],
   "template": {
@@ -37,14 +38,15 @@ Charts are defined by JSON documents (`specification`) which are then linked to 
 
 
 ## Inputs
-The inputs array specifies the parameters required by the template, in order to generate a complete vega specification. The `dataset.mappings` hash must contain entries for all the `required:true` inputs.
+The inputs array specifies the parameters required by the template, in order to generate a complete vega specification. The `dataset.mappings` hash must contain entries for all the `required:true` inputs. Inputs with `required:false` can provide a default value.
 
 ### Inputs Example
 ```
 {
   "inputs": [
     {"name": "count", "type": ["numeric","string"], "required": true},
-    {"name": "group", "type": ["string"], "required": false}
+    {"name": "group", "type": ["string"], "required": false},
+    {"name": "color", "type":["string"], "required":false, "default":"steelblue"}
   ]
 }
 ```

--- a/site/source/pages/examples/bar-spec-defaults.hbs
+++ b/site/source/pages/examples/bar-spec-defaults.hbs
@@ -1,0 +1,191 @@
+---
+layout: example.hbs
+---
+<style>
+  #mappings:{min-height:150px;}
+</style>
+
+{{#markdown}}
+# Optional Inputs with Defaults
+
+The specification can provide default values for non-required inputs. In this example, the `color` input is optional and defaults to `steelblue`.
+In the dataset, we specify `color:orange`, thus the chart is orange.
+
+Clicking the Clear Color button will remote color from the mappings, and then the default of `steelblue` will be used. 
+
+You can also provide a color (name or #RRGGBB) in the input box and use the Add Color button, which will add it to the mappings and update the chart.
+
+{{/markdown}}
+
+<div id="chart"></div>
+<div class="row">
+  <div class="col-lg-4">
+    <h3>Controls</h3>
+    <form>
+     
+      <div class="form-group">
+        <label for="color">Color</label>
+        <input type="text" id="color" value="green">
+      </div>
+      <button id="removeColor" class="btn btn-default" type="button">Clear Color</button>
+      <button id="setColor" class="btn btn-default"  type="button">Add Color</button>
+    </form>
+  </div>
+  
+  <div class="col-lg-8">
+    <h3>Mappings</h3>
+    <pre id="mappings">
+      
+    </pre>
+  </div>
+</div>
+
+
+
+
+
+<script>
+  //create a cedar chart
+  var chart = new Cedar();
+
+  //create the specification
+  var spec = {
+  "inputs": [
+    {"name": "count", "type": ["numeric","string"], "required": true},
+    {"name": "group", "type": ["string"], "required": false},
+    {"name": "color", "type":["string"], "required":false, "default":"steelblue"},
+    {"name": "hoverColor", "type":["string"], "required":false, "default":"#FF00FF"},
+  ],
+  "template":{
+    "axes": [
+      {
+        "type": "x",
+        "scale": "x",
+        "title": "X-Axis"
+      }
+    ],
+    "data": [
+      {
+        "name": "table",
+        "url": "{data}",
+        "format": {
+          "property": "features"
+        }
+      }
+    ],
+    "height": 300,
+    "marks": [
+      {
+        "from": {
+          "data": "table"
+        },
+        "properties": {
+          "enter": {
+            "width": {
+              "band": true,
+              "offset": -1,
+              "scale": "x"
+            },
+            "x": {
+              "field": "data.attributes.{group.field}",
+              "scale": "x"
+            },
+            "y": {
+              "field": "data.attributes.{count.field}_SUM",
+              "scale": "y"
+            },
+            "y2": {
+              "scale": "y",
+              "value": 0
+            }
+          },
+          "hover": {
+            "fill": {
+              "value": "{hoverColor}"
+            }
+          },
+          "update": {
+            "fill": {
+              "value": "{color}"
+            }
+          }
+        },
+        "type": "rect"
+      }
+    ],
+    "padding": {
+      "bottom": 20,
+      "left": 80,
+      "right": 10,
+      "top": 10
+    },
+    "scales": [
+      {
+        "domain": {
+          "data": "table",
+          "field": "data.attributes.{group.field}"
+        },
+        "name": "x",
+        "range": "width",
+        "type": "ordinal"
+      },
+      {
+        "domain": {
+          "data": "table",
+          "field": "data.attributes.{count.field}_SUM"
+        },
+        "name": "y",
+        "nice": true,
+        "range": "height"
+      }
+    ],
+    "width": 850
+  }
+}
+
+  //assign to chart
+  chart.specification = spec;
+
+  //create the dataset w/ mappings
+  var dataset = {
+    "url":"http://maps2.dcgis.dc.gov/dcgis/rest/services/DCGIS_DATA/Education_WebMercator/MapServer/5",
+    "mappings":{
+      "group": {"field":"ZIP_CODE","label":"ZIP Code"},
+      "count": {"field":"TOTAL_STUD","label":"Total Students"},
+      "color": "orange",
+      "hoverColor":"#CCCCCC"
+
+    }
+  };
+
+
+
+  //assign to the chart
+  chart.dataset = dataset;
+
+  //show the chart
+  chart.show({
+    elementId: "#chart"
+  });
+
+  showMapping();
+
+  document.getElementById("removeColor").addEventListener("click", function( event ) {
+    delete chart.dataset.mappings.color
+    showMapping();
+    chart.update();
+
+  });
+
+  document.getElementById("setColor").addEventListener("click", function( event ) {
+    //get the value from the text input
+    chart.dataset.mappings.color = document.getElementById('color').value;
+    showMapping();
+    chart.update();
+  });
+
+  function showMapping(){
+    document.querySelector('#mappings').innerHTML =JSON.stringify(chart.dataset.mappings, null, ' ');
+  }
+
+</script>

--- a/site/source/pages/examples/filter-chart-by-bbox.hbs
+++ b/site/source/pages/examples/filter-chart-by-bbox.hbs
@@ -15,19 +15,27 @@ layout: example.hbs
 <link rel="stylesheet" href="http://js.arcgis.com/3.12/esri/css/esri.css">
 <script src="http://js.arcgis.com/3.12/"></script>
 
+{{#markdown}}
 
-<h1>Filter Chart by Geometry</h1>
-<p>This example shows how to filter the charted data based on a geometry passed into to the `dataset.query`. For simplicity, the example simply uses the map extent, but it could be any arbitrary geometry.</p>
+# Filter Chart by BBOX
+
+This example shows how to filter the charted data based on a bounding box (bbox). Setting `dataset.query.bbox` is simply a convenience method as compared to setting the `dataset.query.geometry`.
+
+**Note:** BBOX expects comma delimited string of geographic (lat/long) coordinates as follows: West,East,South,North
+
+**Note:** Setting both a `bbox` and a `geometry` on the `dataset.query` object will cause an exception to be thrown.
+{{/markdown}}
+
 <div id="map"></div>
 <div id="chart"></div>
 
 
-
 {{#markdown}}
+
 ```html
 {{>example-code-header}}
   
-  require(["esri/map", "esri/layers/FeatureLayer", "esri/symbols/SimpleMarkerSymbol", "esri/symbols/SimpleLineSymbol",
+    require(["esri/map", "esri/layers/FeatureLayer", "esri/symbols/SimpleMarkerSymbol", "esri/symbols/SimpleLineSymbol",
     "esri/renderers/SimpleRenderer",  "esri/renderers/UniqueValueRenderer", "esri/Color", "dojo/domReady!"], function(Map, FeatureLayer, 
        SimpleMarkerSymbol, SimpleLineSymbol, SimpleRenderer, UniqueValueRenderer, Color) { 
 
@@ -74,7 +82,7 @@ layout: example.hbs
       }
     };
 
-    var chart = new Cedar({"specification":"{{assets}}/data/templates/bar.json", "dataset": dataset});
+    var chart = new Cedar({"specification":"../data/templates/bar.json", "dataset": dataset});
 
     chart.override = {
       "height": 300,
@@ -92,9 +100,9 @@ layout: example.hbs
     window.chart = chart;
 
     function onExtentChanged(){
-      var extent = map.extent;
-      extent = JSON.stringify(extent);
-      chart.dataset.query.geometry = extent;
+      var extent = map.geographicExtent.toJson();
+      //WESN order
+      chart.dataset.query.bbox = extent.xmin + ',' + extent.xmax + ',' + extent.ymin + ',' + extent.ymax;
       chart.update();
     }
 
@@ -172,9 +180,9 @@ layout: example.hbs
     window.chart = chart;
 
     function onExtentChanged(){
-      var extent = map.extent;
-      extent = JSON.stringify(extent);
-      chart.dataset.query.geometry = extent;
+      var extent = map.geographicExtent.toJson();
+      //WESN order
+      chart.dataset.query.bbox = extent.xmin + ',' + extent.xmax + ',' + extent.ymin + ',' + extent.ymax;
       chart.update();
     }
 

--- a/site/source/partials/sidebar-examples.hbs
+++ b/site/source/partials/sidebar-examples.hbs
@@ -17,6 +17,7 @@
       <li><a href="{{assets}}examples/bar-spec-url.html">Specification URL</a></li>
       <li><a href="{{assets}}examples/bar-spec-inlined.html">Inline Specification</a></li>
       <li><a href="{{assets}}examples/bar-spec-override.html">Style Overrides</a></li>
+      <li><a href="{{assets}}examples/bar-spec-defaults.html">Defaults</a></li>
     </ul>
   </nav>
 
@@ -39,7 +40,8 @@
     <ul>
       <li><a href="{{assets}}examples/bar-map-integration.html">With JS API Map</a></li>
       <li><a href="{{assets}}examples/bar-map-leaflet-integration.html">With Leaflet Map</a></li>
-      <li><a href="{{assets}}examples/filter-chart-by-map-extent.html">Filter Chart by Map Extent</a></li>
+      <li><a href="{{assets}}examples/filter-chart-by-map-extent.html">Filter by Geometry</a></li>
+      <li><a href="{{assets}}examples/filter-chart-by-bbox.html">Filter by BBOX</a></li>
     </ul>
   </nav>
 


### PR DESCRIPTION
Adds support for defaults to the inputs hash, and applies them if the mappings do not include the values. Also updated relevant docs.

Adds the query.bbox convenience method & updated filter by geometry example

Mistakenly pushed to esridc.github.io so... examples
http://esridc.github.io/cedar/examples/bar-spec-defaults.html
http://esridc.github.io/cedar/examples/filter-chart-by-bbox.html