### PR TITLE
pass at response charts

### DIFF
--- a/site/source/pages/examples/responsive-example.hbs
+++ b/site/source/pages/examples/responsive-example.hbs
@@ -1,0 +1,137 @@
+---
+title: Bar Chart
+layout: example.hbs
+---
+
+
+<h1>Responsive Bar Chart</h1>
+
+<div id="chart"></div>
+
+
+
+{{#markdown}}
+```html
+{{>example-code-header}}
+  function drawChart() {
+    //create a cedar chart - passing a url to the spec
+    var chart = new Cedar({"specification":"{{assets}}data/templates/bar.json"});
+
+    //create the dataset w/ mappings
+    var dataset = {
+      "url":"http://maps2.dcgis.dc.gov/dcgis/rest/services/DCGIS_DATA/Education_WebMercator/MapServer/5",
+      "mappings":{
+        "group": {"field":"ZIP_CODE","label":"ZIP Code"},
+        "count": {"field":"TOTAL_STUD","label":"Total Students"}
+      }
+    };
+
+    //assign to the chart
+    chart.dataset = dataset;
+
+    var el = document.getElementById("chart");
+    var width = el.offsetWidth;
+    var height = el.offsetHeight;
+
+    chart.override = {
+      "height": height,
+      "width": width,
+      "marks": [{"properties": {
+          "hover": {"fill": {"value": "#3ba3d0"}},
+          "update": {"fill": {"value": "#7de6ff"}}
+        }
+      }]
+    };
+
+    //show the chart
+    chart.show({
+      elementId: "#chart"
+    });
+
+    window.chart = chart;
+  };
+
+
+  drawChart();
+
+  window.onresize = updateChart;
+
+  function updateChart() {
+    var el = document.getElementById("chart");
+    var width = el.offsetWidth;
+    
+    chart.override = {
+      "width": width,
+      "marks": [{"properties": {
+          "hover": {"fill": {"value": "#3ba3d0"}},
+          "update": {"fill": {"value": "#7de6ff"}}
+        }
+      }]
+    }
+
+    chart.update();
+  }
+{{>example-code-footer}}
+```
+{{/markdown}}
+
+<script>
+  function drawChart() {
+    //create a cedar chart - passing a url to the spec
+    var chart = new Cedar({"specification":"{{assets}}data/templates/bar.json"});
+
+    //create the dataset w/ mappings
+    var dataset = {
+      "url":"http://maps2.dcgis.dc.gov/dcgis/rest/services/DCGIS_DATA/Education_WebMercator/MapServer/5",
+      "mappings":{
+        "group": {"field":"ZIP_CODE","label":"ZIP Code"},
+        "count": {"field":"TOTAL_STUD","label":"Total Students"}
+      }
+    };
+
+    //assign to the chart
+    chart.dataset = dataset;
+
+    var el = document.getElementById("chart");
+    var width = el.offsetWidth;
+    var height = el.offsetHeight;
+
+    chart.override = {
+      "height": height,
+      "width": width,
+      "marks": [{"properties": {
+          "hover": {"fill": {"value": "#3ba3d0"}},
+          "update": {"fill": {"value": "#7de6ff"}}
+        }
+      }]
+    };
+
+    //show the chart
+    chart.show({
+      elementId: "#chart"
+    });
+
+    window.chart = chart;
+  };
+
+
+  drawChart();
+
+  window.onresize = updateChart;
+
+  function updateChart() {
+    var el = document.getElementById("chart");
+    var width = el.offsetWidth;
+    
+    chart.override = {
+      "width": width,
+      "marks": [{"properties": {
+          "hover": {"fill": {"value": "#3ba3d0"}},
+          "update": {"fill": {"value": "#7de6ff"}}
+        }
+      }]
+    }
+
+    chart.update();
+  }
+</script>

--- a/site/source/partials/sidebar-examples.hbs
+++ b/site/source/partials/sidebar-examples.hbs
@@ -48,11 +48,12 @@
     </ul>
   </nav>
 
-  <h5>Complex Examples</h5>
+  <h5>Additional Examples</h5>
   <nav>
     <ul>
       <li><a href="{{assets}}examples/complex-map-multiple-chart.html">Map and Multiple Charts</a></li>
       <li><a href="{{assets}}examples/inlined-data.html">Pass Data</a></li>
+      <li><a href="{{assets}}examples/responsive-example.html">Responsive Charts</a></li>
     </ul>
   </nav>
 

--- a/src/cedar.js
+++ b/src/cedar.js
@@ -279,7 +279,6 @@ Cedar.prototype.update = function(){
   }
 };
 
-
 /**
  * Render a fully cooked spec
  */


### PR DESCRIPTION
Closes: https://github.com/esridc/cedar/issues/45

Adds example of a responsive chart based on chart container width. Vega deals with this by calling update on the chart when "onresize" is called on the window. The current implementation has no logic for handling specialized rendering based on screen width, so if a chart as many bins, or very long labels, they will overlap on small screens, like phones. This sounds like something Vega devs are working to address: https://github.com/trifacta/vega/wiki/Interaction-Scenarios#layout--resizability 

I'm submitting this PR as I think it still highlights the functionality okay. We can continue to update this "responsive" example as capabilities grow. The issue w/ small screen sizes is not unique to resizing, but rather how to render charts in small containers/ screens. 

![bar_chart___esri_cedar](https://cloud.githubusercontent.com/assets/910495/5882641/8183d3ea-a308-11e4-887b-2045646ba8ca.png)

![bar_chart___esri_cedar](https://cloud.githubusercontent.com/assets/910495/5882652/90e29c4a-a308-11e4-87e1-0d3e88ae095e.png)

