### PR TITLE
Adds select method and map -> chart interaction example

### DIFF
--- a/site/source/pages/api/select.hbs
+++ b/site/source/pages/api/select.hbs
@@ -1,0 +1,147 @@
+---
+title: Cedar.select Method
+layout: documentation.hbs
+---
+
+## .select( opt )
+Selects chart markers based on "hover" style definition.
+
+`chart.select({key:"Attribute Name", value: "value"});`
+
+#### Arguments
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `key` | `string` | yes | Attribute name of markers rendered in chart. |
+| `value` | `string` | yes | Value of attribute for marker to select. |
+
+<br />
+#### <a href="{{assets}}examples/map-to-chart-interaction.html">Live Example</a>
+
+<br />
+#### Example Code
+```
+<div id='chartDiv'></div>
+
+<script>
+  
+    require(["esri/map", "esri/layers/FeatureLayer", "esri/symbols/SimpleMarkerSymbol", "esri/symbols/SimpleLineSymbol",
+    "esri/renderers/SimpleRenderer",  "esri/renderers/UniqueValueRenderer", "esri/Color", "esri/graphic", "dojo/domReady!"], function(Map, FeatureLayer, 
+       SimpleMarkerSymbol, SimpleLineSymbol, SimpleRenderer, UniqueValueRenderer, Color, Graphic) { 
+
+    var defaultSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbol.STYLE_CIRCLE, 11,
+      new SimpleLineSymbol(SimpleLineSymbol.STYLE_SOLID,
+      new Color([220,220,220]), 0.5),
+      new Color([14,105,175,0.55]));
+
+    var rend = new SimpleRenderer(defaultSymbol);
+
+    var featureLayer = new FeatureLayer("http://maps2.dcgis.dc.gov/dcgis/rest/services/DCGIS_DATA/Education_WebMercator/MapServer/5",{
+      mode: FeatureLayer.SNAPSHOT,
+      outFields: ["*"]
+    });
+
+    //create esri map
+    var map = new Map("map", {
+      center: [-77, 38.9],
+      zoom: 11,
+      basemap: "topo",
+      smartNavigation: false
+    });
+
+    map.on('load', function() {
+      map.disableScrollWheelZoom();
+    });
+
+    featureLayer.setRenderer(rend);
+    map.addLayer(featureLayer);
+    
+    //create a cedar chart
+    var chart = new Cedar({
+      "specification":"../data/templates/bar.json"
+    });
+
+    chart.override = {
+      "height": 400,
+      "marks": [{"properties": {
+        "hover": {"fill": {"value": "#1f4c70"}},
+        "update": {"fill": {"value": "#0e69af"}}}}]};
+
+
+    //create the dataset w/ mappings
+    var dataset = {
+      "url":"http://maps2.dcgis.dc.gov/dcgis/rest/services/DCGIS_DATA/Education_WebMercator/MapServer/5",
+      "mappings":{
+        "group": {"field":"ZIP_CODE","label":"ZIP Code"},
+        "count": {"field":"TOTAL_STUD","label":"Total Students"}
+      }
+    };
+
+    //assign to the chart
+    chart.dataset = dataset;
+
+    //show the chart
+    chart.show({
+      elementId: "#chart",
+      renderer: "svg"
+    });
+    
+
+    //CHART EVENTS
+    chart.on('mouseover', onChartHover);
+
+    function onChartHover(d) {
+      
+      //get selected value for attribute in chart marker
+      var selected = d[dataset.mappings.group.field];
+      
+      //create renderer
+      var renderer = new UniqueValueRenderer(defaultSymbol, dataset.mappings.group.field);
+
+      //add symbol selected value
+      renderer.addValue(selected, new SimpleMarkerSymbol().setColor(new Color([14,105,175, 0.5])));
+
+      featureLayer.setRenderer(renderer);
+      featureLayer.refresh();
+
+    } 
+
+    window.chart = chart;
+
+
+    map.on("load", function() {
+      map.graphics.enableMouseEvents();
+      map.graphics.on("mouse-out", onMouseout);
+    });
+
+    function onMouseout(d) {
+      
+      map.graphics.clear();
+
+      chart.update();
+
+    }
+
+    //MAP EVENTS
+    featureLayer.on('mouse-over', function(d) {
+
+      var highlightSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbol.STYLE_CIRCLE, 11,
+        new SimpleLineSymbol(SimpleLineSymbol.STYLE_SOLID,
+        new Color([255,255,255]), 1.5),
+        new Color([14,105,175,0.8]));
+
+      var highlightGraphic = new Graphic(d.graphic.geometry,highlightSymbol);
+      highlightGraphic.attributes = d.graphic.attributes;
+      map.graphics.add(highlightGraphic);
+
+
+      var val = d.graphic.attributes["ZIP_CODE"];
+      chart.select({key: "ZIP_CODE", value: val});
+
+    });
+
+
+  });
+
+</script>
+```

--- a/site/source/pages/examples/map-to-chart-interaction.hbs
+++ b/site/source/pages/examples/map-to-chart-interaction.hbs
@@ -17,11 +17,11 @@ layout: example.hbs
 ```html
 {{>example-code-header}}
   
-  require(["esri/map", "esri/layers/FeatureLayer", "esri/symbols/SimpleMarkerSymbol", "esri/symbols/SimpleLineSymbol",
-    "esri/renderers/SimpleRenderer",  "esri/renderers/UniqueValueRenderer", "esri/Color", "dojo/domReady!"], function(Map, FeatureLayer, 
-       SimpleMarkerSymbol, SimpleLineSymbol, SimpleRenderer, UniqueValueRenderer, Color) { 
+    require(["esri/map", "esri/layers/FeatureLayer", "esri/symbols/SimpleMarkerSymbol", "esri/symbols/SimpleLineSymbol",
+    "esri/renderers/SimpleRenderer",  "esri/renderers/UniqueValueRenderer", "esri/Color", "esri/graphic", "dojo/domReady!"], function(Map, FeatureLayer, 
+       SimpleMarkerSymbol, SimpleLineSymbol, SimpleRenderer, UniqueValueRenderer, Color, Graphic) { 
 
-    var defaultSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbol.STYLE_CIRCLE, 9,
+    var defaultSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbol.STYLE_CIRCLE, 11,
       new SimpleLineSymbol(SimpleLineSymbol.STYLE_SOLID,
       new Color([220,220,220]), 0.5),
       new Color([14,105,175,0.55]));
@@ -74,7 +74,8 @@ layout: example.hbs
 
     //show the chart
     chart.show({
-      elementId: "#chart"
+      elementId: "#chart",
+      renderer: "svg"
     });
     
 
@@ -99,16 +100,38 @@ layout: example.hbs
 
     window.chart = chart;
 
-    //MAP EVENTS
-    featureLayer.on('mouse-over', function(d) {
-      var val = d.graphic.attributes["ZIP_CODE"];
-      chart.select("ZIP_CODE", val);
+
+    map.on("load", function() {
+      map.graphics.enableMouseEvents();
+      map.graphics.on("mouse-out", onMouseout);
     });
 
-    featureLayer.on('mouse-out', function(d) {
+    function onMouseout(d) {
+      
+      map.graphics.clear();
+
+      chart.update();
+
+    }
+
+    //MAP EVENTS
+    featureLayer.on('mouse-over', function(d) {
+
+      var highlightSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbol.STYLE_CIRCLE, 11,
+        new SimpleLineSymbol(SimpleLineSymbol.STYLE_SOLID,
+        new Color([255,255,255]), 1.5),
+        new Color([14,105,175,0.8]));
+
+      var highlightGraphic = new Graphic(d.graphic.geometry,highlightSymbol);
+      highlightGraphic.attributes = d.graphic.attributes;
+      map.graphics.add(highlightGraphic);
+
+
       var val = d.graphic.attributes["ZIP_CODE"];
-      chart.clearSelect("ZIP_CODE", val);
+      chart.select({key: "ZIP_CODE", value: val});
+
     });
+
 
   });
 {{>example-code-footer}}
@@ -211,8 +234,7 @@ layout: example.hbs
       
       map.graphics.clear();
 
-      var val = d.graphic.attributes["ZIP_CODE"];
-      chart.clearSelect("ZIP_CODE", val);
+      chart.update();
 
     }
 
@@ -230,7 +252,7 @@ layout: example.hbs
 
 
       var val = d.graphic.attributes["ZIP_CODE"];
-      chart.select("ZIP_CODE", val);
+      chart.select({key: "ZIP_CODE", value: val});
 
     });
 

--- a/site/source/pages/examples/map-to-chart-interaction.hbs
+++ b/site/source/pages/examples/map-to-chart-interaction.hbs
@@ -1,0 +1,240 @@
+---
+layout: example.hbs
+---
+
+<link rel="stylesheet" href="http://js.arcgis.com/3.12/esri/css/esri.css">
+<script src="http://js.arcgis.com/3.12/"></script>
+
+
+<h1>Map to Chart Interaction</h1>
+
+<div id="map"></div>
+<div id="chart"></div>
+
+
+
+{{#markdown}}
+```html
+{{>example-code-header}}
+  
+  require(["esri/map", "esri/layers/FeatureLayer", "esri/symbols/SimpleMarkerSymbol", "esri/symbols/SimpleLineSymbol",
+    "esri/renderers/SimpleRenderer",  "esri/renderers/UniqueValueRenderer", "esri/Color", "dojo/domReady!"], function(Map, FeatureLayer, 
+       SimpleMarkerSymbol, SimpleLineSymbol, SimpleRenderer, UniqueValueRenderer, Color) { 
+
+    var defaultSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbol.STYLE_CIRCLE, 9,
+      new SimpleLineSymbol(SimpleLineSymbol.STYLE_SOLID,
+      new Color([220,220,220]), 0.5),
+      new Color([14,105,175,0.55]));
+
+    var rend = new SimpleRenderer(defaultSymbol);
+
+    var featureLayer = new FeatureLayer("http://maps2.dcgis.dc.gov/dcgis/rest/services/DCGIS_DATA/Education_WebMercator/MapServer/5",{
+      mode: FeatureLayer.SNAPSHOT,
+      outFields: ["*"]
+    });
+
+    //create esri map
+    var map = new Map("map", {
+      center: [-77, 38.9],
+      zoom: 11,
+      basemap: "topo",
+      smartNavigation: false
+    });
+
+    map.on('load', function() {
+      map.disableScrollWheelZoom();
+    });
+
+    featureLayer.setRenderer(rend);
+    map.addLayer(featureLayer);
+    
+    //create a cedar chart
+    var chart = new Cedar({
+      "specification":"../data/templates/bar.json"
+    });
+
+    chart.override = {
+      "height": 400,
+      "marks": [{"properties": {
+        "hover": {"fill": {"value": "#1f4c70"}},
+        "update": {"fill": {"value": "#0e69af"}}}}]};
+
+
+    //create the dataset w/ mappings
+    var dataset = {
+      "url":"http://maps2.dcgis.dc.gov/dcgis/rest/services/DCGIS_DATA/Education_WebMercator/MapServer/5",
+      "mappings":{
+        "group": {"field":"ZIP_CODE","label":"ZIP Code"},
+        "count": {"field":"TOTAL_STUD","label":"Total Students"}
+      }
+    };
+
+    //assign to the chart
+    chart.dataset = dataset;
+
+    //show the chart
+    chart.show({
+      elementId: "#chart"
+    });
+    
+
+    //CHART EVENTS
+    chart.on('mouseover', onChartHover);
+
+    function onChartHover(d) {
+      
+      //get selected value for attribute in chart marker
+      var selected = d[dataset.mappings.group.field];
+      
+      //create renderer
+      var renderer = new UniqueValueRenderer(defaultSymbol, dataset.mappings.group.field);
+
+      //add symbol selected value
+      renderer.addValue(selected, new SimpleMarkerSymbol().setColor(new Color([14,105,175, 0.5])));
+
+      featureLayer.setRenderer(renderer);
+      featureLayer.refresh();
+
+    } 
+
+    window.chart = chart;
+
+    //MAP EVENTS
+    featureLayer.on('mouse-over', function(d) {
+      var val = d.graphic.attributes["ZIP_CODE"];
+      chart.select("ZIP_CODE", val);
+    });
+
+    featureLayer.on('mouse-out', function(d) {
+      var val = d.graphic.attributes["ZIP_CODE"];
+      chart.clearSelect("ZIP_CODE", val);
+    });
+
+  });
+{{>example-code-footer}}
+```
+{{/markdown}}
+
+
+<script>
+
+  require(["esri/map", "esri/layers/FeatureLayer", "esri/symbols/SimpleMarkerSymbol", "esri/symbols/SimpleLineSymbol",
+    "esri/renderers/SimpleRenderer",  "esri/renderers/UniqueValueRenderer", "esri/Color", "esri/graphic", "dojo/domReady!"], function(Map, FeatureLayer, 
+       SimpleMarkerSymbol, SimpleLineSymbol, SimpleRenderer, UniqueValueRenderer, Color, Graphic) { 
+
+    var defaultSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbol.STYLE_CIRCLE, 11,
+      new SimpleLineSymbol(SimpleLineSymbol.STYLE_SOLID,
+      new Color([220,220,220]), 0.5),
+      new Color([14,105,175,0.55]));
+
+    var rend = new SimpleRenderer(defaultSymbol);
+
+    var featureLayer = new FeatureLayer("http://maps2.dcgis.dc.gov/dcgis/rest/services/DCGIS_DATA/Education_WebMercator/MapServer/5",{
+      mode: FeatureLayer.SNAPSHOT,
+      outFields: ["*"]
+    });
+
+    //create esri map
+    var map = new Map("map", {
+      center: [-77, 38.9],
+      zoom: 11,
+      basemap: "topo",
+      smartNavigation: false
+    });
+
+    map.on('load', function() {
+      map.disableScrollWheelZoom();
+    });
+
+    featureLayer.setRenderer(rend);
+    map.addLayer(featureLayer);
+    
+    //create a cedar chart
+    var chart = new Cedar({
+      "specification":"../data/templates/bar.json"
+    });
+
+    chart.override = {
+      "height": 400,
+      "marks": [{"properties": {
+        "hover": {"fill": {"value": "#1f4c70"}},
+        "update": {"fill": {"value": "#0e69af"}}}}]};
+
+
+    //create the dataset w/ mappings
+    var dataset = {
+      "url":"http://maps2.dcgis.dc.gov/dcgis/rest/services/DCGIS_DATA/Education_WebMercator/MapServer/5",
+      "mappings":{
+        "group": {"field":"ZIP_CODE","label":"ZIP Code"},
+        "count": {"field":"TOTAL_STUD","label":"Total Students"}
+      }
+    };
+
+    //assign to the chart
+    chart.dataset = dataset;
+
+    //show the chart
+    chart.show({
+      elementId: "#chart",
+      renderer: "svg"
+    });
+    
+
+    //CHART EVENTS
+    chart.on('mouseover', onChartHover);
+
+    function onChartHover(d) {
+      
+      //get selected value for attribute in chart marker
+      var selected = d[dataset.mappings.group.field];
+      
+      //create renderer
+      var renderer = new UniqueValueRenderer(defaultSymbol, dataset.mappings.group.field);
+
+      //add symbol selected value
+      renderer.addValue(selected, new SimpleMarkerSymbol().setColor(new Color([14,105,175, 0.5])));
+
+      featureLayer.setRenderer(renderer);
+      featureLayer.refresh();
+
+    } 
+
+    window.chart = chart;
+
+
+    map.on("load", function() {
+      map.graphics.enableMouseEvents();
+      map.graphics.on("mouse-out", onMouseout);
+    });
+
+    function onMouseout(d) {
+      
+      map.graphics.clear();
+
+      var val = d.graphic.attributes["ZIP_CODE"];
+      chart.clearSelect("ZIP_CODE", val);
+
+    }
+
+    //MAP EVENTS
+    featureLayer.on('mouse-over', function(d) {
+
+      var highlightSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbol.STYLE_CIRCLE, 11,
+        new SimpleLineSymbol(SimpleLineSymbol.STYLE_SOLID,
+        new Color([255,255,255]), 1.5),
+        new Color([14,105,175,0.8]));
+
+      var highlightGraphic = new Graphic(d.graphic.geometry,highlightSymbol);
+      highlightGraphic.attributes = d.graphic.attributes;
+      map.graphics.add(highlightGraphic);
+
+
+      var val = d.graphic.attributes["ZIP_CODE"];
+      chart.select("ZIP_CODE", val);
+
+    });
+
+
+  });
+
+</script>

--- a/site/source/partials/header.hbs
+++ b/site/source/partials/header.hbs
@@ -31,8 +31,8 @@
 
   <!-- esri Cedar -->
   <script type="text/javascript" src="http://square.github.io/crossfilter/d3.v3.min.js"></script>
-  <script type="text/javascript" src="http://trifacta.github.io/vega/vega.js"></script>
-  <!-- <script type="text/javascript" src="{{assets}}js/vega.js"></script> -->
+  <!-- <script type="text/javascript" src="http://trifacta.github.io/vega/vega.js"></script> -->
+  <script type="text/javascript" src="{{assets}}js/vega.js"></script>
   <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.7.0/underscore-min.js"></script>
   <script type="text/javascript" src="{{assets}}js/cedar-core.js"></script>
 

--- a/site/source/partials/header.hbs
+++ b/site/source/partials/header.hbs
@@ -32,6 +32,7 @@
   <!-- esri Cedar -->
   <script type="text/javascript" src="http://square.github.io/crossfilter/d3.v3.min.js"></script>
   <script type="text/javascript" src="http://trifacta.github.io/vega/vega.js"></script>
+  <!-- <script type="text/javascript" src="{{assets}}js/vega.js"></script> -->
   <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.7.0/underscore-min.js"></script>
   <script type="text/javascript" src="{{assets}}js/cedar-core.js"></script>
 

--- a/site/source/partials/sidebar-documentation.hbs
+++ b/site/source/partials/sidebar-documentation.hbs
@@ -14,6 +14,7 @@
     <li><a href="{{assets}}api/update.html">.update( )</a></li>
     <li><a href="{{assets}}api/on.html">.on( evt, fn )</a></li>
     <li><a href="{{assets}}api/off.html">.off( evt )</a></li>
+    <li><a href="{{assets}}api/select.html">.select( opt )</a></li>
   </ul>
 
   <h5>Json Objects</h5>

--- a/site/source/partials/sidebar-examples.hbs
+++ b/site/source/partials/sidebar-examples.hbs
@@ -44,6 +44,7 @@
       <li><a href="{{assets}}examples/bar-map-leaflet-integration.html">With Leaflet Map</a></li>
       <li><a href="{{assets}}examples/filter-chart-by-map-extent.html">Filter by Geometry</a></li>
       <li><a href="{{assets}}examples/filter-chart-by-bbox.html">Filter by BBOX</a></li>
+      <li><a href="{{assets}}examples/map-to-chart-interaction.html">Map to Chart Interaction</a></li>
     </ul>
   </nav>
 

--- a/src/cedar.js
+++ b/src/cedar.js
@@ -268,13 +268,13 @@ if(this._pendingXhr){
 /**
  * highlight marker based on attribute value
  */
-Cedar.prototype.select = function(key, value) {
+Cedar.prototype.select = function( opt ) {
   var self = this;
   var view = this._view;
   var items = view.model().scene().items[0].items[0].items;
 
   items.forEach(function(item) {
-    if ( item.datum.data.attributes[key] === value ) {
+    if ( item.datum.data.attributes[opt.key] === opt.value ) {
       if ( item.hasPropertySet("hover") ) {
         self._view.update({props:"hover", items:item});
       }
@@ -282,22 +282,6 @@ Cedar.prototype.select = function(key, value) {
   });
 
 };
-
-Cedar.prototype.clearSelect = function(key, value) {
-  var self = this;
-  var view = this._view;
-  var items = view.model().scene().items[0].items[0].items;
-
-  items.forEach(function(item) {
-    if ( item.datum.data.attributes[key] === value ) {
-      if ( item.hasPropertySet("hover") ) {
-        self._view.update();
-      }
-    }
-  });
-
-};
-
 
 
 /**

--- a/src/cedar.js
+++ b/src/cedar.js
@@ -259,6 +259,19 @@ if(this._pendingXhr){
   }
 };
 
+
+
+/**
+ * highlight marker based on attribute value
+ */
+Cedar.prototype.highlight = function(value) {
+  var view = this._view;
+  console.log('view', view);
+  console.log('value', value);
+};
+
+
+
 /**
  * Attach the generic proxy handlers to the chart view
  */

--- a/src/cedar.js
+++ b/src/cedar.js
@@ -187,6 +187,7 @@ Cedar.prototype.show = function(options){
   
     //hold onto the id
     this._elementId = options.elementId;
+    this._renderer = options.renderer || "canvas"; //default to canvas
 
     //hold onto the token
     if(options.token){
@@ -243,7 +244,10 @@ if(this._pendingXhr){
       vg.parse.spec(spec, function(chartCtor) { 
 
         //create the view
-        self._view = chartCtor({el: self._elementId});
+        self._view = chartCtor({
+          el: self._elementId,
+          renderer: self._renderer
+        });
         
         //render into the element
         self._view.update(); 
@@ -264,10 +268,34 @@ if(this._pendingXhr){
 /**
  * highlight marker based on attribute value
  */
-Cedar.prototype.highlight = function(value) {
+Cedar.prototype.select = function(key, value) {
+  var self = this;
   var view = this._view;
-  console.log('view', view);
-  console.log('value', value);
+  var items = view.model().scene().items[0].items[0].items;
+
+  items.forEach(function(item) {
+    if ( item.datum.data.attributes[key] === value ) {
+      if ( item.hasPropertySet("hover") ) {
+        self._view.update({props:"hover", items:item});
+      }
+    }
+  });
+
+};
+
+Cedar.prototype.clearSelect = function(key, value) {
+  var self = this;
+  var view = this._view;
+  var items = view.model().scene().items[0].items[0].items;
+
+  items.forEach(function(item) {
+    if ( item.datum.data.attributes[key] === value ) {
+      if ( item.hasPropertySet("hover") ) {
+        self._view.update();
+      }
+    }
+  });
+
 };
 
 


### PR DESCRIPTION
Closes: https://github.com/esridc/cedar/issues/28

Also updates Cedar's "update" method to accept render as "svg" or "canvas". Canvas remains default. 

To render chart as svg, simple pass in as option to show method. 

```
chart.show({
  elementId: "#chart",
  renderer: "svg"
});
```

![esri_cedar](https://cloud.githubusercontent.com/assets/910495/5925924/50c6f222-a624-11e4-844d-72180b743a6b.png)

