### PR TITLE
small typo fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cedar
 
-Cedar is a library for crafting, sharing and data visualizations powered by ArcGIS Services. Built with D3 and the Vega graphics grammar, Cedar extends them with bindings for making templated chart graphics that can be re-used with different datasets. 
+Cedar is a library for crafting, sharing and data visualizations powered by ArcGIS Services. Built with D3 and the Vega graphics grammar, Cedar extends them with bindings for making templated chart graphics that can be re-used with different datasets.
 
 At the highest level, Cedar provides a simple chart API. Beyond that it is possible to create new and unique chart types that can be loaded and customized through interactions and styling depending on your needs.
 
@@ -12,16 +12,16 @@ Cedar charts are defined by the following ingredients:
 
 - a `Specification` is a JSON document which includes,
  - `inputs` that declare the variables of the chart such as category or value to be summarized
- - `template` is a declarative syntax for chart design using the [Vega](http://trifacta.github.io/vega/) visualization grammar. 
-- a `dataset` 
- - either `url` link to the ArcGIS Feature Layer; 
+ - `template` is a declarative syntax for chart design using the [Vega](http://trifacta.github.io/vega/) visualization grammar.
+- a `dataset`
+ - either `url` link to the ArcGIS Feature Layer;
  - ...or `values` can be an array of inline features
  - `mappings` bind the Feature Layer attributes to the `Specification inputs`
 - and `overrides` are specific modifications to the `Specification template`
 
 ## Types of Charts
 
-While Cedar provides a set of commonly used chart types including `Bar`, `Line`, `Scatterplot`, and `Pyramid` through use of the Vega grammar it is possible for developers to create unique and custom charts that can be used by other developers with new data sources. 
+While Cedar provides a set of commonly used chart types including `Bar`, `Line`, `Scatterplot`, and `Pyramid` through use of the Vega grammar it is possible for developers to create unique and custom charts that can be used by other developers with new data sources.
 
 When starting with Cedar, we suggest that you begin by exploring the simple charts using your own data services. As you experiment with the interactions with Maps and more complex interaction you can also customize these charts with new capabilities such as legends, size scaling or labeling. Finally, you can fork and create completely custom chart templates that you then provide for other developers to use through Cedar.
 
@@ -45,7 +45,7 @@ When starting with Cedar, we suggest that you begin by exploring the simple char
   });
 ```
 
-and it is simple to add more charts re-using the same `dataset` definition: 
+and it is simple to add more charts re-using the same `dataset` definition:
 
 
 ```json
@@ -59,15 +59,15 @@ and it is simple to add more charts re-using the same `dataset` definition:
 
 ## Demos
 
-There are is a [simple user interface](http://dbouwman.github.com/cypress] and [a few demos](http://esridc.github.io/cedar/) showing the basic concepts of Cedar.
+Here is a [simple user interface](http://dbouwman.github.com/cypress) and [a few demos](http://esridc.github.io/cedar/) showing the basic concepts of Cedar.
 
 ### Development Instructions
 
-Make Sure you have the [Grunt CLI](http://gruntjs.com/getting-started) installed.
+Make sure you have the [Grunt CLI](http://gruntjs.com/getting-started) installed.
 
 1. `cd` into the `cedar` folder
 1. Install the dependencies with `npm install`
-1. Install additional dependencies with `bower install`
+1. Install additional dependencies with `bower install` (if you encounter an error connecting to github take a look at [this thread](https://github.com/angular/angular-phonecat/issues/141) for a possible fix).
 1. Run `grunt docs` from the command line. This will start the web server locally at [http://localhost:8001](http://localhost:8001) and start watching the source files and running linting and testing commands.
 1. Push your changes using `grunt docs:build` which pushes to your `origin/gh-pages`
 1. Create a [pull request](https://help.github.com/articles/creating-a-pull-request) to `esridc/cedar/master`
@@ -78,7 +78,7 @@ Make Sure you have the [Grunt CLI](http://gruntjs.com/getting-started) installed
 * [Vega](http://trifacta.github.io/vega/)
 
 ### Versioning
- 
+
 For transparency into the release cycle and in striving to maintain backward compatibility, Cedar is maintained under the Semantic Versioning guidelines and will adhere to these rules whenever possible.
 
 Releases will be numbered with the following format:
@@ -95,7 +95,7 @@ For more information on SemVer, please visit <http://semver.org/>.
 
 
 ### Licensing
-Copyright 2014 Esri
+Copyright 2015 Esri
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "cedar",
   "version": "0.0.0",
-  "homepage": "https://github.com/dbouwman/cedar",
+  "homepage": "https://github.com/esridc/cedar",
   "authors": [
     "Dave Bouwman <dave@davebouwman.com>"
   ],


### PR DESCRIPTION
added note in README which explains how to resolve errors with `bower install` when connecting to `git://github.com` behind a firewall (i hit the problem myself)
bumped copyright
changed url in bower.json to point at `esridc/cedar` instead of `dbouwman/cedar`
fixed a mismatched hyperlink tag
etc.