### PR TITLE
changing bar chart defaults and adding more examples

### DIFF
--- a/site/source/data/definitions/dc-schools-scatter-chart.json
+++ b/site/source/data/definitions/dc-schools-scatter-chart.json
@@ -72,7 +72,8 @@
           "scale": "y",
           "offset": 5,
           "ticks": 5,
-          "title": "{y.label}"
+          "title": "{y.label}",
+          "titleOffset": 60
         }
       ],
       "legends": [

--- a/site/source/data/definitions/home-scatter-chart.json
+++ b/site/source/data/definitions/home-scatter-chart.json
@@ -72,7 +72,8 @@
           "scale": "y",
           "offset": 5,
           "ticks": 5,
-          "title": "{y.label}"
+          "title": "{y.label}",
+          "titleOffset": 60
         }
       ],
       "legends": [

--- a/site/source/data/templates/bar.json
+++ b/site/source/data/templates/bar.json
@@ -4,19 +4,21 @@
     {"name": "group", "type": ["string"], "required": false}
   ],
   "template":{
-    "height": 300,
-    "width": 850,    
-    "padding": {
-      "bottom": 20,
-      "left": 10,
-      "right": 10,
-      "top": 10
-    },
+    "height": 325,
+    "width": 850,
     "axes": [
       {
         "type": "x",
         "scale": "x",
-        "title": "X-Axis"
+        "titleOffset": 45,
+        "title": "{group.label}",
+        "properties": {
+          "labels": {
+            "angle": {"value": 50},
+            "align": {"value": "left"},
+            "baseline": {"value": "middle"}
+          }
+        }
       }
     ],
     "data": [
@@ -36,10 +38,10 @@
             "y2": {"scale": "y", "value": 0 }
           },
           "hover": {
-            "fill": {"value": "green"}
+            "fill": {"value": "#1c5d87"}
           },
           "update": {
-            "fill": {"value": "#ccc"}
+            "fill": {"value": "#256e9d"}
           }
         },
         "type": "rect"

--- a/site/source/data/templates/scatter.json
+++ b/site/source/data/templates/scatter.json
@@ -61,7 +61,8 @@
         "scale": "y",
         "offset": 5,
         "ticks": 5,
-        "title": "{y.label}"
+        "title": "{y.label}",
+        "titleOffset": 50
       }
     ],
     "legends": [

--- a/site/source/pages/examples/style-overrides.hbs
+++ b/site/source/pages/examples/style-overrides.hbs
@@ -1,0 +1,95 @@
+---
+layout: example.hbs
+---
+
+<div class="row">
+  <div class="col-lg-8" >
+    <h3>Bar Chart Overrides</h3>
+    <span>Common bar chart style overrides.</span>
+    
+    <h5>Override default width (850px) and height (325px)</h5>
+    {{#markdown}}
+      chart.override = {
+        "height": 200,
+        "width": 850
+      };
+    {{/markdown}}
+    
+    <br />
+    <h5>Override default x-label title placement (i.e. to account for long labels). Default 40px.</h5>
+    {{#markdown}}
+      chart.override = {
+        "axes": [
+          {
+            "titleOffset": 100
+          }
+        ]
+      };
+    {{/markdown}}
+
+    <br />
+    <h5>Override default default chart color (#256e9d).</h5>
+    <span>The following sets the main color (update) to light green, and the hover style to dark green.</span>
+    {{#markdown}}
+      chart.override = {
+        "marks": [
+          {"properties": 
+            {
+              "hover": {"fill": {"value": "#17a086"}},
+              "update": {"fill": {"value": "#7fcdbb"}}
+            }
+          }
+        ]
+      };
+    {{/markdown}}
+
+    <br />
+    <h5>For for further chart defaults, inspect the template. Modify these defaults in chart.override.</h5>
+    {{#markdown}}
+      var tmpl = chart.specification.template;
+    {{/markdown}}
+
+    <div id="chart-bar"></div>
+  </div>
+</div>
+
+<script>
+
+  //create a cedar chart, passing a url to a spec
+  var barChart = new Cedar({"specification":"{{assets}}data/templates/bar.json"});
+  //create the dataset w/ mappings
+  var dataset = {
+    "url":"http://services.arcgis.com/pmcEyn9tLWCoX7Dm/arcgis/rest/services/CA_Hospitals/FeatureServer/0",
+    "mappings":{
+      "group": { "field": "Hospital_Ownership", "label": "Hospital Owndership" },
+      "count": { "field": "Number_of_Patients" }
+    }
+  };
+
+  //assign to the chart
+  barChart.dataset = dataset;
+
+  //show the chart
+  barChart.show({
+    elementId: "#chart-bar"
+  });
+
+  barChart.override = {
+    "height": 200,
+    "width": 850,
+    "marks": [
+      {"properties": 
+        {
+          "hover": {"fill": {"value": "#17a086"}},
+          "update": {"fill": {"value": "#7fcdbb"}}
+        }
+      }
+    ],
+    "axes": [
+      {
+        "titleOffset": 100
+      }
+    ]
+  };
+
+</script>

--- a/site/source/partials/sidebar-examples.hbs
+++ b/site/source/partials/sidebar-examples.hbs
@@ -18,8 +18,8 @@
     <ul>
       <li><a href="{{assets}}examples/bar-spec-url.html">Specification URL</a></li>
       <li><a href="{{assets}}examples/bar-spec-inlined.html">Inline Specification</a></li>
-      <li><a href="{{assets}}examples/bar-spec-override.html">Style Overrides</a></li>
       <li><a href="{{assets}}examples/bar-spec-defaults.html">Defaults</a></li>
+      <li><a href="{{assets}}examples/style-overrides.html">Style Overrides</a></li>
     </ul>
   </nav>
 


### PR DESCRIPTION
The main purpose of this PR is to continue to improve the bar chart defaults. On Friday we discussed making x-labels default to an angle, to assure no overlaps would ever occur. Developers can still override this in their custom specification, or using chart.override. This closes: https://github.com/esridc/cedar/issues/65. 

Additional changes to the default bar chart specification include adding {group.label} instead of hardcoded "X Axis" and changing default colors to blue instead of gray. 

The PR also includes the start of an example page (formerly 404) to show some common chart.override use cases. Currently examples for setting height/width, bar marker colors, and x axis title placement. 